### PR TITLE
Change location of gem binary

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -84,7 +84,7 @@ gempath:
 EOF
 
 # install bundler
-/usr/local/bin/gem install bundler > /dev/null
+/usr/bin/env gem install bundler > /dev/null
 
 cd $SITE_DIR
 


### PR DESCRIPTION
I wanted to use this buildpack with [Dokku](https://github.com/progrium/dokku), but the hardcoded path for gem doesn't work.

I've changed the path to `/usr/bin/env gem` which works with both Dokku and Heroku.
